### PR TITLE
Pytorch branch compatibility fixes for 0.3

### DIFF
--- a/fcn_maker/blocks.py
+++ b/fcn_maker/blocks.py
@@ -139,7 +139,7 @@ def merge(tensors, mode):
     if mode=='sum':
         out = tensors[0]
         for t in tensors[1:]:
-            out += t
+            out = out + t
     elif mode=='concat':
         out = torch.cat(tensors, dim=1)
     return out


### PR DESCRIPTION
+ tensors prefer tuples of slices for indexing, not lists
+ inplace operations on tensors sometimes cause trouble, better to use `x = x + y`